### PR TITLE
[Minishell][Execution] Implemented Pipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ MINI_UTILS_SRC = $(UTILS_DIR)/utils.c
 
 # Execution
 EXEC_DIR = src/execution
-MINI_EXEC_SRC = $(EXEC_DIR)/execution.c
+MINI_EXEC_SRC = $(EXEC_DIR)/execution.c $(EXEC_DIR)/piping.c
 
 # Combined
 MINI_SRC = $(MINI_TOKENISATION_SRC) $(MINI_AST_SRC) $(MINI_ENV_SRC) $(MINI_UTILS_SRC) $(MINI_EXEC_SRC)

--- a/inc/execution.h
+++ b/inc/execution.h
@@ -34,6 +34,8 @@ typedef struct  s_mini
 
 char	*find_executable(const char *command, t_env_list *env_list);
 void	execute_command_node(t_ast_node *node, t_mini *shell);
+void	execute_pipe(t_ast_node *node, t_mini *shell);
+void	execute_ast(t_ast_node *node, t_mini *shell);
 
 #endif
 

--- a/src/execution/execution.c
+++ b/src/execution/execution.c
@@ -84,16 +84,8 @@ static void	_execute_simple_command(char *cmd_path)
 	exit(EXIT_FAILURE);
 }
 
-static void	_execute_child_process(char *cmd_path, t_ast_node *node, t_mini *shell)
+static void	_execute_child_process(char *cmd_path, t_ast_node *node)
 {
-	if (shell->in_fd != STDIN_FILENO) {
-		dup2(shell->in_fd, STDIN_FILENO);
-		close(shell->in_fd);
-	}
-	if (shell->out_fd != STDOUT_FILENO) {
-		dup2(shell->out_fd, STDOUT_FILENO);
-		close(shell->out_fd);
-	}
 	if (node->token_node->token->args)
 		_execute_complex_command(cmd_path, node->token_node->token->args);
 	else
@@ -116,10 +108,17 @@ void	execute_command_node(t_ast_node *node, t_mini *shell)
         exit(EXIT_FAILURE);
     }
     if (pid == 0)
-		_execute_child_process(cmd_path, node, shell);
+		_execute_child_process(cmd_path, node);
     else {
 		waitpid(pid, &status, 0);
 		shell->last_exit_status = WEXITSTATUS(status);
     }
 }
 
+void	execute_ast(t_ast_node *node, t_mini *shell)
+{
+	if (node->type == AST_COMMAND)
+		execute_command_node(node, shell);
+	else if (node->type == AST_PIPE)
+		execute_pipe(node, shell);
+}

--- a/src/execution/piping.c
+++ b/src/execution/piping.c
@@ -1,0 +1,48 @@
+#include <execution.h>
+
+void execute_pipe(t_ast_node *node, t_mini *shell)
+{
+    int		pipe_fd[2];
+    pid_t	pid_left;
+	pid_t	pid_right;
+    int		status;
+
+    if (pipe(pipe_fd) == -1)
+    {
+        perror("pipe");
+        return;
+    }
+    pid_left = fork();
+    if (pid_left == -1)
+    {
+        perror("fork");
+        return;
+    }
+    if (pid_left == 0)
+    {
+        close(pipe_fd[0]);
+        dup2(pipe_fd[1], STDOUT_FILENO);
+        close(pipe_fd[1]);
+        execute_command_node(node->left, shell);
+        _exit(shell->last_exit_status);
+    }
+    pid_right = fork();
+    if (pid_right == -1)
+    {
+        perror("fork");
+        return;
+    }
+    if (pid_right == 0)
+    {
+        close(pipe_fd[1]);
+        dup2(pipe_fd[0], STDIN_FILENO);
+        close(pipe_fd[0]);
+        execute_command_node(node->right, shell);
+        _exit(shell->last_exit_status);
+    }
+    close(pipe_fd[0]);
+    close(pipe_fd[1]);
+    waitpid(pid_left, &status, 0);
+    waitpid(pid_right, &status, 0);
+    shell->last_exit_status = WEXITSTATUS(status);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -46,7 +46,7 @@ int	main(int ac, const char **av, const char **envp)
 			if (mini.head)
 			{
 				print_ast(mini.head);
-				execute_command_node(mini.head, &mini);
+				execute_ast(mini.head, &mini);
 				free_ast(mini.head);
 			}
 			mini.head = NULL;


### PR DESCRIPTION
### Merge Request Description: Implement Pipe Functionality for Command Execution

**Title:** Add Support for Pipe (`|`) in Command Execution

**Description:**

This merge request introduces the functionality to execute commands connected by pipes (`|`) in a shell environment. This feature allows the output of one command to be passed as input to another, a key requirement for Unix-like shell interfaces.

#### Next Steps:
- Extend functionality to support multi-pipe chains.