### PR TITLE
[Minishell][Execution][Heredoc] Implemented heredoc with delimiter handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ MINI_UTILS_SRC = $(UTILS_DIR)/utils.c
 
 # Execution
 EXEC_DIR = src/execution
-MINI_EXEC_SRC = $(EXEC_DIR)/execution.c $(EXEC_DIR)/piping.c $(EXEC_DIR)/redirections.c
+MINI_EXEC_SRC = $(EXEC_DIR)/execution.c $(EXEC_DIR)/piping.c $(EXEC_DIR)/redirections.c $(EXEC_DIR)/heredoc.c
 
 # Combined
 MINI_SRC = $(MINI_TOKENISATION_SRC) $(MINI_AST_SRC) $(MINI_ENV_SRC) $(MINI_UTILS_SRC) $(MINI_EXEC_SRC) $(MINI_SIGNALS_SRC)

--- a/inc/execution.h
+++ b/inc/execution.h
@@ -35,6 +35,15 @@ typedef struct  s_mini
 	int				last_exit_status;
 }               t_mini;
 
+typedef struct	s_heredoc_data
+{
+	pid_t		pid;
+	t_ast_node	*node;
+	t_mini		*shell;
+	int			pipe_fd[2];
+	int			original_stdin;
+}	t_heredoc_data;
+
 char	*find_executable(const char *command, t_env_list *env_list);
 void	execute_command_node(t_ast_node *node, t_mini *shell, t_bool is_another_process);
 void	execute_pipe(t_ast_node *node, t_mini *shell);
@@ -42,6 +51,7 @@ void	execute_ast(t_ast_node *node, t_mini *shell);
 void	execute_redirect_out(t_ast_node *node, t_mini *shell);
 void	execute_redirect_in(t_ast_node *node, t_mini *shell);
 void	execute_redirect_append(t_ast_node *node, t_mini *shell);
+void	execute_redirect_heredoc(t_ast_node *node, t_mini *shell);
 
 #endif
 

--- a/src/execution/execution.c
+++ b/src/execution/execution.c
@@ -127,6 +127,78 @@ void	execute_command_node(t_ast_node *node, t_mini *shell, t_bool is_another_pro
 	}
 }
 
+void execute_redirect_heredoc(t_ast_node *node, t_mini *shell)
+{
+    int pipe_fd[2];
+    char *line;
+    char *delimiter;
+    int original_stdin;
+    pid_t pid;
+
+    if (!node || !node->right || !node->right->token_node) {
+        fprintf(stderr, "heredoc: invalid syntax\n");
+        return;
+    }
+
+    delimiter = node->right->token_node->token->value;
+    if (!delimiter) {
+        fprintf(stderr, "heredoc: missing delimiter\n");
+        return;
+    }
+
+    if (pipe(pipe_fd) == -1) {
+        perror("pipe");
+        return;
+    }
+
+    original_stdin = dup(STDIN_FILENO); // Save original stdin
+
+    pid = fork();
+    if (pid == -1) {
+        perror("fork");
+        return;
+    }
+
+    if (pid == 0)  // Child process: Read input and write to pipe
+    {
+        close(pipe_fd[0]); // Close read-end, only writing
+
+        while (1) {
+            line = readline("> ");
+            if (!line) break;
+
+            // Stop reading if the delimiter is found
+            if (strcmp(line, delimiter) == 0) {
+                free(line);
+                break;
+            }
+
+            write(pipe_fd[1], line, strlen(line));
+            write(pipe_fd[1], "\n", 1);
+            free(line);
+        }
+        close(pipe_fd[1]); // Close write-end
+        exit(EXIT_SUCCESS); // Only child process exits
+    }
+    else  // Parent process: Redirect stdin and execute command
+    {
+        int status;
+        waitpid(pid, &status, 0); // Wait for heredoc input process
+
+        close(pipe_fd[1]); // Close write-end, only reading
+        dup2(pipe_fd[0], STDIN_FILENO); // Redirect stdin to pipe
+        close(pipe_fd[0]);
+
+        // Execute the next command
+        execute_ast(node->left, shell);
+
+        // Restore original stdin
+        dup2(original_stdin, STDIN_FILENO);
+        close(original_stdin);
+    }
+}
+
+
 void	_execute_redirect(t_ast_node *node, t_mini *shell)
 {
 	if (node->type == AST_REDIRECT_IN)
@@ -135,6 +207,8 @@ void	_execute_redirect(t_ast_node *node, t_mini *shell)
 		execute_redirect_out(node, shell);
 	else if (node->type == AST_APPEND)
 		execute_redirect_append(node, shell);
+	else if (node->type == AST_HEREDOC)
+		execute_redirect_heredoc(node, shell);
 	// TODO: RETURN TO THE MINISHEEL INTERFACE FOR INPUT
 }
 
@@ -147,7 +221,9 @@ void	execute_ast(t_ast_node *node, t_mini *shell)
 		execute_command_node(node, shell, true);
 	else if (node->type == AST_PIPE)
 		execute_pipe(node, shell);
-	else if (node->type == AST_REDIRECT_IN || node->type == AST_REDIRECT_OUT || node->type == AST_APPEND)
+	else if (node->type == AST_REDIRECT_IN || node->type == AST_REDIRECT_OUT \
+		|| node->type == AST_APPEND || node->type == AST_HEREDOC)
 		_execute_redirect(node, shell);
+	
 	// Add support for other types of nodes
 }

--- a/src/execution/execution.c
+++ b/src/execution/execution.c
@@ -127,76 +127,7 @@ void	execute_command_node(t_ast_node *node, t_mini *shell, t_bool is_another_pro
 	}
 }
 
-void execute_redirect_heredoc(t_ast_node *node, t_mini *shell)
-{
-    int pipe_fd[2];
-    char *line;
-    char *delimiter;
-    int original_stdin;
-    pid_t pid;
 
-    if (!node || !node->right || !node->right->token_node) {
-        fprintf(stderr, "heredoc: invalid syntax\n");
-        return;
-    }
-
-    delimiter = node->right->token_node->token->value;
-    if (!delimiter) {
-        fprintf(stderr, "heredoc: missing delimiter\n");
-        return;
-    }
-
-    if (pipe(pipe_fd) == -1) {
-        perror("pipe");
-        return;
-    }
-
-    original_stdin = dup(STDIN_FILENO); // Save original stdin
-
-    pid = fork();
-    if (pid == -1) {
-        perror("fork");
-        return;
-    }
-
-    if (pid == 0)  // Child process: Read input and write to pipe
-    {
-        close(pipe_fd[0]); // Close read-end, only writing
-
-        while (1) {
-            line = readline("> ");
-            if (!line) break;
-
-            // Stop reading if the delimiter is found
-            if (strcmp(line, delimiter) == 0) {
-                free(line);
-                break;
-            }
-
-            write(pipe_fd[1], line, strlen(line));
-            write(pipe_fd[1], "\n", 1);
-            free(line);
-        }
-        close(pipe_fd[1]); // Close write-end
-        exit(EXIT_SUCCESS); // Only child process exits
-    }
-    else  // Parent process: Redirect stdin and execute command
-    {
-        int status;
-        waitpid(pid, &status, 0); // Wait for heredoc input process
-
-        close(pipe_fd[1]); // Close write-end, only reading
-        dup2(pipe_fd[0], STDIN_FILENO); // Redirect stdin to pipe
-        close(pipe_fd[0]);
-
-        // Execute the next command
-        execute_ast(node->left, shell);
-
-        // Restore original stdin
-        dup2(original_stdin, STDIN_FILENO);
-        close(original_stdin);
-    }
-}
 
 
 void	_execute_redirect(t_ast_node *node, t_mini *shell)

--- a/src/execution/heredoc.c
+++ b/src/execution/heredoc.c
@@ -1,0 +1,72 @@
+#include <execution.h>
+
+void execute_redirect_heredoc(t_ast_node *node, t_mini *shell)
+{
+    int pipe_fd[2];
+    char *line;
+    char *delimiter;
+    int original_stdin;
+    pid_t pid;
+
+    if (!node || !node->right || !node->right->token_node) {
+        fprintf(stderr, "heredoc: invalid syntax\n");
+        return;
+    }
+
+    delimiter = node->right->token_node->token->value;
+    if (!delimiter) {
+        fprintf(stderr, "heredoc: missing delimiter\n");
+        return;
+    }
+
+    if (pipe(pipe_fd) == -1) {
+        perror("pipe");
+        return;
+    }
+
+    original_stdin = dup(STDIN_FILENO); // Save original stdin
+
+    pid = fork();
+    if (pid == -1) {
+        perror("fork");
+        return;
+    }
+
+    if (pid == 0)  // Child process: Read input and write to pipe
+    {
+        close(pipe_fd[0]); // Close read-end, only writing
+
+        while (1) {
+            line = readline("> ");
+            if (!line) break;
+
+            // Stop reading if the delimiter is found
+            if (strcmp(line, delimiter) == 0) {
+                free(line);
+                break;
+            }
+
+            write(pipe_fd[1], line, strlen(line));
+            write(pipe_fd[1], "\n", 1);
+            free(line);
+        }
+        close(pipe_fd[1]); // Close write-end
+        exit(EXIT_SUCCESS); // Only child process exits
+    }
+    else  // Parent process: Redirect stdin and execute command
+    {
+        int status;
+        waitpid(pid, &status, 0); // Wait for heredoc input process
+
+        close(pipe_fd[1]); // Close write-end, only reading
+        dup2(pipe_fd[0], STDIN_FILENO); // Redirect stdin to pipe
+        close(pipe_fd[0]);
+
+        // Execute the next command
+        execute_ast(node->left, shell);
+
+        // Restore original stdin
+        dup2(original_stdin, STDIN_FILENO);
+        close(original_stdin);
+    }
+}

--- a/src/execution/heredoc.c
+++ b/src/execution/heredoc.c
@@ -1,5 +1,15 @@
 #include <execution.h>
 
+static int	ft_strcmp(const char *s1, const char *s2)
+{
+	while (*s1 && (*s1 == *s2))
+	{
+		s1++;
+		s2++;
+	}
+	return (*(unsigned char *)s1 - *(unsigned char *)s2);
+}
+
 static void	_execute_pipe_read(t_heredoc_data *data)
 {
 	char	*line;
@@ -9,8 +19,8 @@ static void	_execute_pipe_read(t_heredoc_data *data)
 	{
 		line = readline("> ");
 		if (!line) break;
-		if (!strcmp(line, data->node->right->token_node->token->value)) // TODO: Change to ft_strncmp
-		{
+		if (!ft_strcmp(line, data->node->right->token_node->token->value))
+		{ 
 			free(line);
 			break;
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -48,7 +48,7 @@ int	main(int ac, const char **av, const char **envp)
 			mini.head = primary_parse(tokens_list);
 			if (mini.head)
 			{
-				// print_ast(mini.head);
+				print_ast(mini.head);
 				execute_ast(mini.head, &mini);
 				free_ast(mini.head);
 			}


### PR DESCRIPTION
**Title:** Refactor Heredoc Execution for Improved Code Structure

**Description:**
This merge request refactors the heredoc execution logic in `execute_redirect_heredoc` by separating the read and write operations into dedicated functions. The changes improve code clarity, modularity, and maintainability while preserving expected functionality.

### **Changes Introduced:**
- Introduced a **`t_heredoc_data`** struct to encapsulate heredoc-related data.
- Extracted heredoc input handling into `_execute_pipe_read` to manage reading from the user and writing to a pipe.
- Moved execution logic into `_execute_pipe_write`, handling process synchronization and restoring `STDIN_FILENO`.
- Used `waitpid` to ensure the parent waits for the child process before redirecting input.
- Ensured `STDIN_FILENO` is properly restored after executing the command.
- Added a **TODO** to replace `strcmp` with `ft_strncmp` for consistency with project functions.

### **Why This Change?**
- **Improves Readability:** Breaking down the logic into dedicated functions makes the code easier to understand and maintain.
- **Enhances Modularity:** Each function now has a clear responsibility, making future modifications simpler.
- **Ensures Proper Cleanup:** The parent process restores the original `STDIN_FILENO`, preventing unintended shell behavior.

### **Testing Performed:**
- Verified that heredoc input is correctly captured and passed to commands.
- Ensured that `STDIN_FILENO` is restored after execution.
- Tested heredoc usage with `cat`, `grep`, and `wc` to confirm expected behavior.